### PR TITLE
Enables customization of results page

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -37,6 +37,7 @@ param_env_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
+  - { env_var: "CUSTOM_RESULTS", env_value: "true", desc: "(optional) enables custom results page in `/config/www/results/index.php`."}
   - { env_var: "DB_TYPE", env_value: "sqlite", desc: "Defaults to `sqlite`, can also be set to `mysql` or `postgresql`."}
   - { env_var: "DB_NAME", env_value: "DB_NAME", desc: "Database name. Required for mysql and pgsql."}
   - { env_var: "DB_HOSTNAME", env_value: "DB_HOSTNAME", desc: "Database address. Required for mysql and pgsql."}
@@ -56,6 +57,8 @@ app_setup_block: |
   
   If you are setting up a mysql or postgresql database, you first need to import the tables into your database as described at the following link  
   https://github.com/librespeed/speedtest/blob/master/doc.md#creating-the-database
+
+  To enable a custom results page set the environment variable `CUSTOM_RESULTS` and start (or restart) the container at least once for `/config/www/results/index.php` to be created and modify this file to your liking.
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,7 +58,7 @@ app_setup_block: |
   If you are setting up a mysql or postgresql database, you first need to import the tables into your database as described at the following link  
   https://github.com/librespeed/speedtest/blob/master/doc.md#creating-the-database
 
-  To enable a custom results page set the environment variable `CUSTOM_RESULTS` and start (or restart) the container at least once for `/config/www/results/index.php` to be created and modify this file to your liking.
+  To enable a custom results page set the environment variable `CUSTOM_RESULTS=true` and start (or restart) the container at least once for `/config/www/results/index.php` to be created and modify this file to your liking.
 
 # changelog
 changelogs:

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -48,22 +48,6 @@ elif [ "$DB_TYPE" = "mysql" ]; then
 		s|\$MySql_hostname=\"DB_HOSTNAME\";|\$MySql_hostname=\"${DB_HOSTNAME}\";|g; \
 		s|\$MySql_databasename=\"DB_NAME\";|\$MySql_databasename=\"${DB_NAME}\";|g" \
 		/usr/share/webapps/librespeed/results/telemetry_settings.php
-# elif [ "$ALEX" = "true" ]; then
-# 	echo "1"
-	#[[ ! -e "/config/results/index.php" ]] && \
-		#mv /usr/share/webapps/librespeed/results/index.php /config/results/index.php
-	#ln -sf /config/results/index.php /usr/share/webapps/librespeed/results/index.php
-
-	# [[ ! -L /config/www/results ]] && \
-	# 	mkdir -p /config/www/results && \
-	# # update results/index.php
-	# [[ ! -L /config/www/results/index.php ]] && \
-	# 	cp /usr/share/webapps/librespeed/results/index.php /config/www/results/index.php
-	# # symlink results file
-	# rm /usr/share/webapps/librespeed/results/index.php
-	# ln -s /config/www/results/index.php /usr/share/webapps/librespeed/results/index.php
-	# chmod -R 664 /config/www/results
-	# chmod +x /config/www/results
 else
 	sed -i \
 		"s|\$db_type=\"mysql\";|\$db_type=\"sqlite\";|g" \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -2,7 +2,8 @@
 
 # make our folders
 mkdir -p \
-	/config/www
+	/config/www \
+	/config/www/img
 
 # create symlink to index.html
 [[ ! -L /usr/share/webapps/librespeed/index.html ]] && \
@@ -16,6 +17,15 @@ cp /usr/share/webapps/librespeed/example*.html /config/www/
 	cp /config/www/speedtest.js /usr/share/webapps/librespeed/speedtest.js
 [[ -f /config/www/speedtest_worker.js ]] && \
 	cp /config/www/speedtest_worker.js /usr/share/webapps/librespeed/speedtest_worker.js
+
+# enables custom results page
+if "$CUSTOM_RESULTS"; then
+	echo "custom results"
+	[[ ! -e "/config/www/results/index.php" ]] && \
+		mkdir -p /config/www/results/ && \
+		mv /usr/share/webapps/librespeed/results/index.php /config/www/results/index.php
+	ln -sf /config/www/results/index.php /usr/share/webapps/librespeed/results/index.php
+fi
 
 # configure app settings
 sed -i "\
@@ -38,6 +48,22 @@ elif [ "$DB_TYPE" = "mysql" ]; then
 		s|\$MySql_hostname=\"DB_HOSTNAME\";|\$MySql_hostname=\"${DB_HOSTNAME}\";|g; \
 		s|\$MySql_databasename=\"DB_NAME\";|\$MySql_databasename=\"${DB_NAME}\";|g" \
 		/usr/share/webapps/librespeed/results/telemetry_settings.php
+# elif [ "$ALEX" = "true" ]; then
+# 	echo "1"
+	#[[ ! -e "/config/results/index.php" ]] && \
+		#mv /usr/share/webapps/librespeed/results/index.php /config/results/index.php
+	#ln -sf /config/results/index.php /usr/share/webapps/librespeed/results/index.php
+
+	# [[ ! -L /config/www/results ]] && \
+	# 	mkdir -p /config/www/results && \
+	# # update results/index.php
+	# [[ ! -L /config/www/results/index.php ]] && \
+	# 	cp /usr/share/webapps/librespeed/results/index.php /config/www/results/index.php
+	# # symlink results file
+	# rm /usr/share/webapps/librespeed/results/index.php
+	# ln -s /config/www/results/index.php /usr/share/webapps/librespeed/results/index.php
+	# chmod -R 664 /config/www/results
+	# chmod +x /config/www/results
 else
 	sed -i \
 		"s|\$db_type=\"mysql\";|\$db_type=\"sqlite\";|g" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Enables feature requested in #6. 

* This PR adds code to `50-config` which enables customization of the results page and stores it in `/config/www/results/index.php`.
* This also adds a directory in `/config/www/img` for custom image assets as requested in #6 as well.

## Benefits of this PR and context:
See #6.

## How Has This Been Tested?
Built locally and works as expected. I customized the title in the bottom right from "LibreSpeed" to "KTZ LibreSpeed".

![image](https://user-images.githubusercontent.com/2773080/93692282-313cff00-fabf-11ea-80e1-8372ab9be69d.png)

Also updated the readme-vars to reflect this new optional parameter.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
