### PR TITLE
Added Support for ipinfo.io access token

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,7 @@ opt_param_env_vars:
   - { env_var: "DB_USERNAME", env_value: "DB_USERNAME", desc: "Database username. Required for mysql and pgsql."}
   - { env_var: "DB_PASSWORD", env_value: "DB_PASSWORD", desc: "Database password. Required for mysql and pgsql."}
   - { env_var: "DB_PORT", env_value: "DB_PORT", desc: "Database port. Required for mysql."}
+  - { env_var: "IPINFO_APIKEY", env_value: "ACCESS_TOKEN", desc: "Access token from ipinfo.io. Required for detailed IP information."}
 
 optional_block_1: false
 optional_block_1_items: ""
@@ -64,6 +65,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "14.05.23:", desc: "Added support for ipinfo.io" }
   - { date: "20.01.23:", desc: "Rebase to alpine 3.17 with php8.1." }
   - { date: "20.08.22:", desc: "Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "01.03.21:", desc: "Fix up database settings. Make sure `index.html` is recreated." }

--- a/root/etc/s6-overlay/s6-rc.d/init-librespeed-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-librespeed-config/run
@@ -21,6 +21,12 @@ if [[ -f /config/www/speedtest_worker.js ]]; then
     cp /config/www/speedtest_worker.js /app/www/public/speedtest_worker.js
 fi
 
+# sets apikey for ipinfo.io, if it exists
+if [ -n "$IPINFO_APIKEY" ]; then
+    sed -i "s/\$IPINFO_APIKEY = .*/\$IPINFO_APIKEY = '${IPINFO_APIKEY:-}';/g" \
+    /app/www/public/backend/getIP_ipInfo_apikey.php
+fi
+
 # enables custom results page
 if [ "$CUSTOM_RESULTS" == "true" ]; then
     echo "custom results"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added environment variable IPINFO_APIKEY to set access token from ipinfo.io

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-librespeed/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Librespeed already provides support to set access token from ipinfo.io in backend/getIP_ipInfo_apikey.php file.
This PR just gives users ability to setup the access token with the IPINFO_APIKEY environment variable, which
was missing.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Users will be able to set access token for ipinfo.io

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR has been tested by running docker build and [Jenkins Builder](https://github.com/linuxserver/docker-jenkins-builder) locally. This has been tested on x86_64 machine. This change sets access token for ipinfo.io and missingauth message also disappears.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
