### PR TITLE
Replace php mysqli with php pdo_pgsql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   echo "**** install packages ****" && \
   apk add --no-cache \
     php82-gd \
-    php82-mysqli \
+    php82-pdo_mysql \
     php82-pdo_pgsql \
     php82-pdo_sqlite && \
   echo "**** install librespeed ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,7 +13,7 @@ RUN \
   echo "**** install packages ****" && \
   apk add --no-cache \
     php82-gd \
-    php82-mysqli \
+    php82-pdo_mysql \
     php82-pdo_pgsql \
     php82-pdo_sqlite && \
   echo "**** install librespeed ****" && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -64,6 +64,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.12.23:", desc: "Replace php mysqli with php pdo_pgsql." }
   - { date: "25.05.23:", desc: "Rebase to Alpine 3.18, deprecate armhf." }
   - { date: "14.05.23:", desc: "Added support for ipinfo.io" }
   - { date: "20.01.23:", desc: "Rebase to alpine 3.17 with php8.1." }


### PR DESCRIPTION
Closes https://github.com/linuxserver/docker-librespeed/issues/27
Upstream does not use mysqli (they only use PDO)